### PR TITLE
[ITEM] 광고 제거 아이템 추가

### DIFF
--- a/server/src/models/Item.ts
+++ b/server/src/models/Item.ts
@@ -1,13 +1,13 @@
 import { Schema, Types, model } from "mongoose";
 
-export interface IItem {
+export interface ItemEntity {
   _id: Types.ObjectId;
-  type: "chartSkin";
+  type: "chartSkin" | "advertisement";
   title: string;
   price: Number;
 }
 
-export const itemSchema = new Schema<IItem>(
+export const itemSchema = new Schema<ItemEntity>(
   {
     type: String,
     title: String,
@@ -18,5 +18,5 @@ export const itemSchema = new Schema<IItem>(
 
 itemSchema.index({ type: 1, title: 1 });
 
-const Item = model<IItem>("Item", itemSchema);
-export { Item };
+const ItemModel = model<ItemEntity>("Item", itemSchema);
+export { ItemModel };

--- a/server/src/models/Payment.ts
+++ b/server/src/models/Payment.ts
@@ -58,7 +58,7 @@ export type TRawPayment = {
   customer_uid_usage: "issue";
 };
 
-export interface IPayment {
+export interface PaymentEntity {
   _id: Types.ObjectId;
   merchant_uid: string; // same as _id
 
@@ -76,7 +76,7 @@ export interface IPayment {
   rawPaymentData: any;
 }
 
-export const paymentSchema = new Schema<IPayment>(
+export const paymentSchema = new Schema<PaymentEntity>(
   {
     merchant_uid: String,
 
@@ -101,5 +101,5 @@ paymentSchema.pre("save", function (next) {
   next();
 });
 
-const Payment = model<IPayment>("Payment", paymentSchema);
-export { Payment };
+const PaymentModel = model<PaymentEntity>("Payment", paymentSchema);
+export { PaymentModel };

--- a/server/src/services/items.ts
+++ b/server/src/services/items.ts
@@ -1,4 +1,4 @@
-import { Item as ItemModel } from "src/models/Item";
+import { ItemModel } from "src/models/Item";
 
 export const create = async (
   type: "chartSkin",

--- a/server/src/services/payments.ts
+++ b/server/src/services/payments.ts
@@ -1,4 +1,4 @@
-import { IItem } from "@models/Item";
+import { ItemEntity } from "@models/Item";
 import { UserEntity } from "@models/User";
 import axios from "axios";
 import { NotPermittedError } from "src/errors/ForbiddenError";
@@ -10,11 +10,7 @@ import {
   PaymentIsNotPaidError,
 } from "src/errors/PaymentError";
 import { HydratedDocument, Types } from "mongoose";
-import {
-  IPayment,
-  Payment as PaymentModel,
-  TRawPayment,
-} from "src/models/Payment";
+import { PaymentEntity, PaymentModel, TRawPayment } from "src/models/Payment";
 
 /**
  * @function getAccessToken
@@ -143,7 +139,7 @@ export const findPaymentsByUserId = async (userId: Types.ObjectId | string) => {
 
 export const createPaymentReady = async (
   userRecord: UserEntity,
-  itemRecord: IItem
+  itemRecord: ItemEntity
 ) => {
   const paymentRecord = await PaymentModel.create({
     userId: userRecord._id,
@@ -225,6 +221,8 @@ export const completePaymentByWebhook = async (imp_uid: string) => {
   throw new FakePaymentAttemptError();
 };
 
-export const remove = async (paymentRecord: HydratedDocument<IPayment>) => {
+export const remove = async (
+  paymentRecord: HydratedDocument<PaymentEntity>
+) => {
   await paymentRecord.remove();
 };


### PR DESCRIPTION
- Closes #600

`{ type: "advertisement", title: "remove-ads" }` 아이템을 DEV, PROD 환경에 추가했습니다.
차트스킨 아이템 구매할 때와 동일한 API를 활용하면 되고, itemTitle로 "remove-ads"를 전달해주시면 됩니다.

추가로, /current API 응답값으로 "items"를 추가했습니다. 결제가 완료된 item 목록을 반환합니다 (이 변경사항은 서버 배포시 반영됩니다).
![image](https://github.com/during-budget/during-web/assets/19641212/973f3f9a-2847-4b9d-80d2-ac025914061d)
