### PR TITLE
Payment / CompleteByMobileUser API 확장 - IOS 지원

### DIFF
--- a/server/src/api/routes/payments.ts
+++ b/server/src/api/routes/payments.ts
@@ -56,7 +56,7 @@ router.post(
           }
 
           case InAppPlatform.IOS: {
-            for (let field of ["payload"]) {
+            for (let field of ["payload", "isSendbox"]) {
               if (!(field in body)) throw new FieldRequiredError(field);
             }
 

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -98,6 +98,7 @@ const config: configType = {
       private_key: process.env.GOOGLE_CREDENTIALS_PRIVATE_KEY,
     };
   })(),
+  APPLE_SHARED_SECRET: process.env.APPLE_SHARED_SECRET ?? "",
 };
 
 console.log(`✅ config is set; `, config);

--- a/server/src/config/type.ts
+++ b/server/src/config/type.ts
@@ -33,6 +33,7 @@ type configType = {
 
   GOOGLE_CREDENTIALS: Pick<JWTInput, "client_email" | "private_key">;
 
+  APPLE_SHARED_SECRET: string;
   //   SERVER_URL: string;
 
   //   CLIENT: string;

--- a/server/src/errors/CustomError.ts
+++ b/server/src/errors/CustomError.ts
@@ -3,4 +3,10 @@ export class CustomError extends Error {
     super();
     this.name = "Error";
   }
+
+  protected logError(debug?: Object) {
+    if (debug) {
+      console.log("[ERROR]", this.message, debug);
+    }
+  }
 }

--- a/server/src/errors/PaymentError.ts
+++ b/server/src/errors/PaymentError.ts
@@ -47,3 +47,33 @@ export class FakePaymentAttemptError extends PaymentError {
     this.status = 409;
   }
 }
+
+export class PaymentValidationFailedError extends PaymentError {
+  constructor(debug?: Object) {
+    super();
+    this.message = "PAYMENT_VALIDATION_FAILED";
+    this.status = 409;
+
+    this.logError(debug);
+  }
+}
+
+export class PaymentItemNotMatchError extends PaymentError {
+  constructor(debug?: Object) {
+    super();
+    this.message = "PAYMENT_ITEM_NOT_MATCH";
+    this.status = 409;
+
+    this.logError(debug);
+  }
+}
+
+export class PaymentUIDDuplicatedError extends PaymentError {
+  constructor(debug?: Object) {
+    super();
+    this.message = "PAYMENT_UID_DUPLICATED";
+    this.status = 409;
+
+    this.logError(debug);
+  }
+}

--- a/server/src/lib/IAPHelper.ts
+++ b/server/src/lib/IAPHelper.ts
@@ -1,0 +1,98 @@
+import axios from "axios";
+
+// 애플 영수증 검증 URL
+const APPLE_PRODUCTION_URL = "https://buy.itunes.apple.com/verifyReceipt";
+const APPLE_SANDBOX_URL = "https://sandbox.itunes.apple.com/verifyReceipt";
+
+// NOTE: https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app
+type AppleReceiptInfo = {
+  quantity: string; // ex) "1";
+  product_id: string; // ex) "bunny"
+  transaction_id: string; // A unique identifier for a transaction such as a purchase, restore, or renewal.
+  original_transaction_id: string; // ex) "2000000651969443";
+  purchase_date: string; // ex) "2024-07-10 02:28:41 Etc/GMT";
+  purchase_date_ms: string; // ex) "1720578521000";
+  purchase_date_pst: string; // ex) "2024-07-09 19:28:41 America/Los_Angeles";
+  original_purchase_date: string; // ex) "2024-07-10 02:28:41 Etc/GMT";
+  original_purchase_date_ms: string; // ex) "1720578521000";
+  original_purchase_date_pst: string; // ex)  "2024-07-09 19:28:41 America/Los_Angeles";
+  is_trial_period: string; // ex) "false";
+};
+
+// NOTE: https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt
+type AppleReceipt = {
+  receipt_type: string;
+  adam_id: string;
+  app_item_id: string;
+  bundle_id: string;
+  application_version: string;
+  download_id: string;
+  version_external_identifier: string;
+  receipt_creation_date: string;
+  receipt_creation_date_ms: string;
+  receipt_creation_date_pst: string;
+  request_date: string;
+  request_date_ms: string;
+  request_date_pst: string;
+  original_purchase_date: string;
+  original_purchase_date_ms: string;
+  original_purchase_date_pst: string;
+  original_application_version: string;
+  in_app: Array<AppleReceiptInfo>;
+};
+
+export enum AppleVerifyReceiptResultStatus {
+  Success = 0,
+  Error000 = 21000, // The request to the App Store didn’t use the HTTP POST request method.
+  Error001 = 21001, // The App Store no longer sends this status code.
+  Error002 = 21002, // The data in the receipt-data property is malformed or the service experienced a temporary issue. Try again.
+  Error003 = 21003, // The system couldn’t authenticate the receipt.
+  Error004 = 21004, // The shared secret you provided doesn’t match the shared secret on file for your account.
+  Error005 = 21005, // The receipt server was temporarily unable to provide the receipt. Try again.
+  Error006 = 21006, // This receipt is valid, but the subscription is in an expired state. When your server receives this status code, the system also decodes and returns receipt data as part of the response. This status only returns for iOS 6-style transaction receipts for auto-renewable subscriptions.
+  Error007 = 21007, // This receipt is from the test environment, but you sent it to the production environment for verification.
+  Error008 = 21008, // This receipt is from the production environment, but you sent it to the test environment for verification.
+  Error009 = 21009, // Internal data access error. Try again later.
+  Error010 = 21010, // The system can’t find the user account or the user account has been deleted.
+}
+
+// NOTE: https://developer.apple.com/documentation/appstorereceipts/responsebody
+type AppleVerifyReceiptResult = {
+  receipt: AppleReceipt;
+  environment: "Sendbox" | "Production";
+  latest_receipt_info: Array<AppleReceiptInfo>;
+  // latest_receipt
+  status: AppleVerifyReceiptResultStatus;
+};
+
+class AppleReceiptVerifier {
+  static async validate(
+    receipt: string,
+    isSendbox: boolean = true
+  ): Promise<{
+    status: AppleVerifyReceiptResultStatus;
+    rawPaymentData: AppleReceiptInfo;
+  }> {
+    const url = isSendbox ? APPLE_SANDBOX_URL : APPLE_PRODUCTION_URL;
+
+    try {
+      const response = await axios.post(url, {
+        "receipt-data": receipt,
+        password: process.env.APPLE_SHARED_SECRET, // 앱의 공유 비밀 키
+      });
+
+      const responseData = response.data as AppleVerifyReceiptResult;
+
+      return {
+        status: responseData.status,
+        rawPaymentData: responseData.latest_receipt_info[0],
+      };
+    } catch (error: any) {
+      throw new Error(`[AppleReceiptVerifier.validate]: ${error.message}`);
+    }
+  }
+}
+
+export class IAPHelper {
+  public static IOS = AppleReceiptVerifier;
+}

--- a/server/src/types/payment.ts
+++ b/server/src/types/payment.ts
@@ -33,6 +33,7 @@ export function validateIOSPayload(
 export type CompletePaymentByIOSReq = {
   platform: InAppPlatform.IOS;
   payload: IOSPayload;
+  isSendbox: boolean;
 };
 
 export type CompletePaymentByMobileUserReq =


### PR DESCRIPTION
- Closes #679 

# Description
## AS-IS
CompleteByMobileUser API(모바일 결제내역 생성 API)는 Android 인앱 결제만 지원했음
- android 인앱 결제 시 request body
    - `platform`: "android" (해당 파라미터는 #678 에서 추가됨)
    - `title`: e.g. "bear"
    - `token`: e.g. "abcdefg..."

## TO-BE
해당 API로 IOS 인앱 결제내역 생성 추가 지원
- ios 인앱 결제 시 request body
    - `platform`: "ios" 
    - `isSendbox`: boolean (새로 추가됨: sendbox 계정으로 테스트하는 경우 true)
    - `payload`: {
        - `transactionDate`: e.g. 12345, 
        - `transactionId`: e.g. "12345", 
        - `productId`: "bunny", 
        -  `transactionReceipt`: "abcde...."
        }

## Todo-List
- env 값 추가 (APPLE_SHARED_SECRET)
- ios 요청 시 `isSendbox` bodyParam 추가
